### PR TITLE
Code clean up

### DIFF
--- a/igcviewer.js
+++ b/igcviewer.js
@@ -1,3 +1,5 @@
+/* global L */
+/* global jQuery */
 (function ($) {
     'use strict';
 
@@ -10,8 +12,7 @@
         offset: 0,
         dst: false
     };
-    var flightarea = null;
-
+    
     var task = null;
 
     function showTask() {
@@ -382,7 +383,6 @@
         var headerBlock = $('#headers');
         headerBlock.html('');
         //Delay display of date till we get the timezone
-        var headerName;
         var headerIndex;
         for (headerIndex = 0; headerIndex < igcFile.headers.length; headerIndex++) {
             headerBlock.append(
@@ -532,12 +532,12 @@
             }
         });
 
-        var altitudeUnit = '', airspaceClip = '';
+        var storedAltitudeUnit = '', airspaceClip = '';
         if (window.localStorage) {
             try {
-                altitudeUnit = localStorage.getItem("altitudeUnit");
-                if (altitudeUnit) {
-                    $('#altitudeUnits').val(altitudeUnit).trigger('change', true);
+                storedAltitudeUnit = localStorage.getItem("altitudeUnit");
+                if (storedAltitudeUnit) {
+                    $('#altitudeUnits').val(storedAltitudeUnit).trigger('change', true);
                 }
 
                 airspaceClip = localStorage.getItem("airspaceClip");

--- a/igcviewer.js
+++ b/igcviewer.js
@@ -404,10 +404,6 @@
         $('#timeSlider').prop('max', igcFile.recordTime.length - 1);
     }
 
-    function pad(n) {
-        return (n < 10) ? ("0" + n) : n;
-    }
-
     function storePreference(name, value) {
         if (window.localStorage) {
             try {

--- a/igcviewer.js
+++ b/igcviewer.js
@@ -1,275 +1,275 @@
 (function ($) {
-   'use strict';
+    'use strict';
 
     var igcFile = null;
     var barogramPlot = null;
-    var altitudeConversionFactor =  3.2808399; // Conversion from metres to required units
-    var timezone =  {
-            zonename:  "Europe/London",
-            zoneabbr: "UTC",
-            offset: 0,
-            dst: false
+    var altitudeConversionFactor = 3.2808399; // Conversion from metres to required units
+    var timezone = {
+        zonename: "Europe/London",
+        zoneabbr: "UTC",
+        offset: 0,
+        dst: false
+    };
+    var flightarea = null;
+
+    var task = null;
+
+    function showTask() {
+        var i;
+        var pointlabel;
+        $('#taskbuttons').html("");
+        $('#taskinfo').html("");
+        for (i = 0; i < task.labels.length; i++) {
+            $('#taskinfo').append('<tr><th>' + task.labels[i] + ':</th><td>' + task.names[i] + ':</td><td>' + task.descriptions[i] + '</td></tr>');
+            switch (i) {
+                case 0:
+                    pointlabel = "Start";
+                    break;
+                case task.labels.length - 1:
+                    pointlabel = "Finish";
+                    break;
+                default:
+                    pointlabel = "TP" + i.toString();
+            }
+            $('#taskbuttons').append('&nbsp;<button>' + pointlabel + '</button>');
+            $('#tasklength').text("Task length: " + task.distance.toFixed(1) + " Km");
+            $('#task').show();
+        }
+    }
+
+    function pointDescription(coords) {
+        var latdegrees = Math.abs(coords['lat']);
+        var latdegreepart = Math.floor(latdegrees);
+        var latminutepart = 60 * (latdegrees - latdegreepart);
+        var latdir = (coords['lat'] > 0) ? "N" : "S";
+        var lngdegrees = Math.abs(coords['lng']);
+        var lngdegreepart = Math.floor(lngdegrees);
+        var lngminutepart = 60 * (lngdegrees - lngdegreepart);
+        var lngdir = (coords['lng'] > 0) ? "E" : "W";
+
+        var retstr = latdegreepart.toString() + "&deg;" + latminutepart.toFixed(3) + "&prime;" + latdir + " " + lngdegreepart.toString() + "&deg;" + lngminutepart.toFixed(3) + "&prime;" + lngdir;
+        return retstr;
+    }
+
+    function clearTask(mapControl) {
+        $('#taskinfo').html("");
+        $('#tasklength').html("");
+        $('#taskbuttons').html("");
+        mapControl.zapTask();
+        $('#task').hide();
+        task = null;
+    }
+
+    //Get display information associated with task
+    function maketask(points) {
+        var i;
+        var j = 1;
+        var distance = 0;
+        var leglength;
+        var names = [];
+        var labels = [];
+        var coords = [];
+        var descriptions = [];
+        names[0] = points.name[0];
+        labels[0] = "Start";
+        coords[0] = points.coords[0];
+        descriptions[0] = pointDescription(points.coords[0]);
+        for (i = 1; i < points.coords.length; i++) {
+            leglength = points.coords[i].distanceTo(points.coords[i - 1]);
+            //eliminate situation when two successive points are identical (produces a divide by zero error on display. 
+            //To allow for FP rounding, within 30 metres is considered identical.
+            if (leglength > 30) {
+                names[j] = points.name[i];
+                coords[j] = points.coords[i];
+                descriptions[j] = pointDescription(points.coords[i]);
+                labels[j] = "TP" + j;
+                distance += leglength;
+                j++;
+            }
+        }
+        labels[labels.length - 1] = "Finish";
+        distance = distance / 1000;
+        var retval = {
+            names: names,
+            labels: labels,
+            coords: coords,
+            descriptions: descriptions,
+            distance: distance
         };
-var flightarea= null;
-
-var task= null;
-
-function showTask()  {
-    var i;
-    var pointlabel;
-    $('#taskbuttons').html("");
-    $('#taskinfo').html("");
-    for(i=0; i < task.labels.length; i++) {
-        $('#taskinfo').append('<tr><th>' + task.labels[i]  +':</th><td>' +task.names[i]  + ':</td><td>' + task.descriptions[i] + '</td></tr>');
-        switch (i)  {
-          case  0:
-              pointlabel="Start";
-              break;
-          case task.labels.length-1:
-              pointlabel="Finish";
-              break;
-          default:
-              pointlabel="TP" + i.toString();
-         }
-        $('#taskbuttons').append('&nbsp;<button>' + pointlabel +'</button>');
-        $('#tasklength').text("Task length: " +  task.distance.toFixed(1) + " Km");
-        $('#task').show();
-    }
-}
-    
-function pointDescription(coords) {
-    var latdegrees= Math.abs(coords['lat']);
-    var latdegreepart=Math.floor(latdegrees);
-    var latminutepart=60*( latdegrees-latdegreepart);
-   var latdir= (coords['lat']  >  0)?"N":"S";
-   var lngdegrees= Math.abs(coords['lng']);
-    var lngdegreepart=Math.floor(lngdegrees);
-    var lngminutepart=60*( lngdegrees-lngdegreepart);
-   var lngdir= (coords['lng']  >  0)?"E":"W";
-   
-    var retstr= latdegreepart.toString() + "&deg;" + latminutepart.toFixed(3) + "&prime;" + latdir + " " + lngdegreepart.toString() + "&deg;" + lngminutepart.toFixed(3) + "&prime;" + lngdir;
-    return retstr;
-}
-
-function clearTask(mapControl) {
-    $('#taskinfo').html("");
-    $('#tasklength').html("");
-     $('#taskbuttons').html("");
-    mapControl.zapTask();
-    $('#task').hide();
-    task= null;
-}
-
-//Get display information associated with task
-function maketask(points) {
-    var i;
-    var j=1;
-    var distance=0;
-    var leglength;
-    var names=[];
-    var labels = [];
-    var coords= [];
-    var descriptions= [];
-   names[0]=points.name[0];
-    labels[0]= "Start";
-    coords[0]=points.coords[0];
-   descriptions[0]=pointDescription(points.coords[0]);
-   for(i=1;i < points.coords.length;i++) {
-        leglength=points.coords[i].distanceTo(points.coords[i-1]);
-        //eliminate situation when two successive points are identical (produces a divide by zero error on display. 
-        //To allow for FP rounding, within 30 metres is considered identical.
-        if(leglength >30) {
-            names[j]= points.name[i];
-            coords[j]= points.coords[i];
-           descriptions[j]=pointDescription(points.coords[i]);
-           labels[j]= "TP" + j;
-            distance += leglength;
-            j++;
-    }
-}
-    labels[labels.length-1]= "Finish";
-    distance= distance/1000;
-    var retval = {
-                                names: names,
-                                labels: labels,
-                                coords: coords,
-                                descriptions: descriptions,
-                                distance: distance
-    };
-    //Must be at least two points more than 30 metres apart
-    if(names.length > 1) {
-         return retval;
-    }
-    else {
-        return null;
-    }
-}
-
-function getPoint(instr) {
-    var latitude;
-    var longitude;
-    var pointname="Not named";
-    var matchref;
-    var statusmessage= "Fail";
-    var count;
-      var pointregex = [
-                                       /^([A-Za-z]{2}[A-Za-z0-9]{1})$/,
-                                    /^([A-Za-z0-9]{6})$/,
-                                   /^([\d]{2})([\d]{2})([\d]{3})([NnSs])([\d]{3})([\d]{2})([\d]{3})([EeWw])(.*)$/,
-                                  /^([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})[\s]*([NnSs])[\W]*([0-9]{1,3}):([0-9]{1,2}):([0-9]{1,2})[\s]*([EeWw])$/,
-                                  /^(\d{1,2})[\s:](\d{1,2})\.(\d{1,3})\s*([NnSs])\s*(\d{1,3})[\s:](\d{1,2})\.(\d{1,3})\s*([EeWw])$/
-];
-for(count=0;count < pointregex.length;count++) {
-        matchref=instr.match(pointregex[count]);
-        if(matchref) {
-            switch(count)  {
-        case 0:
-        case 1:
-            //BGA or Welt2000 point
-           $.ajax({
-                   url: "findtp.php",
-                   data:  {postdata: matchref[0]},
-                      timeout: 3000,
-                      method: "POST",
-                      dataType: "json",
-                      async: false,
-                     success:   function(data) {
-                        pointname=data.tpname;
-                        if(pointname !=="Not found") {
-                          latitude=data.latitude;
-                           longitude=data.longitude;
-                           statusmessage="OK";
-                        }
-                     }
-              });  
-        break;
-        case 2:
-              //format in IGC file
-                 latitude= parseFloat(matchref[1]) + parseFloat(matchref[2])/60 +parseFloat(matchref[3])/60000;
-                if(matchref[4].toUpperCase()==="S") {
-                  latitude=-latitude;  
-                    }
-                 longitude= parseFloat(matchref[5]) + parseFloat(matchref[6])/60 +parseFloat(matchref[7])/60000;
-                if(matchref[8].toUpperCase()==="W") {
-                  longitude=-longitude;  
-                }
-                if(matchref[9].length > 0) {
-                    pointname= matchref[9];
-                }
-                 statusmessage="OK";
-
-            break;
-        case 3:
-            //hh:mm:ss
-            latitude= parseFloat(matchref[1]) + parseFloat(matchref[2])/60 +parseFloat(matchref[3])/3600;
-                if(matchref[4].toUpperCase()==="S") {
-                  latitude=-latitude;  
-                    }
-                 longitude= parseFloat(matchref[5]) + parseFloat(matchref[6])/60 +parseFloat(matchref[7])/3600;
-                if(matchref[8].toUpperCase()==="W") {
-                  longitude=-longitude;  
-                }
-                statusmessage="OK";
-            break;
-        case 4:
-            latitude= parseFloat(matchref[1]) + parseFloat(matchref[2])/60 + parseFloat(matchref[3])/(60*(Math.pow(10,matchref[3].length)));
-                if(matchref[4].toUpperCase()==="S") {
-                  latitude=-latitude;  
-                    }
-                 longitude= parseFloat(matchref[5]) + parseFloat(matchref[6])/60 + parseFloat(matchref[7])/(60*(Math.pow(10,matchref[7].length)));
-                if(matchref[8].toUpperCase()==="W") {
-                  longitude=-longitude;  
-                }
-                statusmessage="OK";
-            break;
-         }
+        //Must be at least two points more than 30 metres apart
+        if (names.length > 1) {
+            return retval;
+        }
+        else {
+            return null;
         }
     }
-    
-     return   {
-       message: statusmessage,
-        coords:  L.latLng(latitude,longitude),
-       name:  pointname
-    };
-    
-}
 
-function parseUserTask() {
-    var input;
-    var pointdata;
-    var success = true;
-    var taskdata =   {
-                                    coords: [],
-                                    name:   []
-                                     }
-     $("#requestdata :input[type=text]").each(function() {
-         input = $(this).val().replace(/ /g,'');
-       if(input.length > 0) {
-          pointdata= getPoint(input);
-          if(pointdata.message==="OK") {
-              taskdata.coords.push(pointdata.coords);
-              taskdata.name.push(pointdata.name);
-          }
-          else {
-             success=false;
-            alert("\""+$(this).val() +"\"" + " not recognised-" + " ignoring entry");
-         }
-       }
-      });
-        if(success) {
-           task= maketask(taskdata);
-        }
-       else {
-           task=null;
-       }
-}
-
-function displaydate(timestamp) {
-    var daynames= ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
-    var monthnames=["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-    
-    return daynames[timestamp.getUTCDay()] +" "+ timestamp.getUTCDate() + " " +monthnames[timestamp.getUTCMonth()] + " " + timestamp.getUTCFullYear();
-}
-
-//get timezone data from timezonedb.  Via php to avoid cross-domain data request from the browser
-//Timezone dependent processes run  on file load are here as request is asynchronous
-//If the request fails or times out, silently reverts to default (UTC)
-function gettimezone(igcFile,mapControl)  {
-    var flightdate= igcFile.recordTime[0];
-   $.ajax({
-                   url: "gettimezone.php",
-                   data:  {
-                             stamp: flightdate/1000,
-                             lat: igcFile.latLong[0][0],
-                             lon: igcFile.latLong[0][1]
-                              },
-                      timeout: 3000,
-                      method: "POST",
-                      dataType: "json",
-                     success:   function(data) {
-                         if(data.status==="OK")  {
-                         timezone.zonename=data.zoneName;
-                          timezone.zoneabbr=data.abbreviation;
-                           timezone.offset=1000*parseFloat(data.gmtOffset);
-                           if (data.dst==="1")  {
-                               timezone.zonename += ", daylight saving";
-                           }
-                         }
-                              }  ,
-                        complete: function() {
-                        //Local date may not be the same as UTC date
-                        var localdate=new Date(flightdate.getTime() + timezone.offset);
-                        $('#datecell').text(displaydate(localdate));
-                        barogramPlot = plotBarogram(igcFile);
-                        updateTimeline(0, mapControl);
+    function getPoint(instr) {
+        var latitude;
+        var longitude;
+        var pointname = "Not named";
+        var matchref;
+        var statusmessage = "Fail";
+        var count;
+        var pointregex = [
+            /^([A-Za-z]{2}[A-Za-z0-9]{1})$/,
+            /^([A-Za-z0-9]{6})$/,
+            /^([\d]{2})([\d]{2})([\d]{3})([NnSs])([\d]{3})([\d]{2})([\d]{3})([EeWw])(.*)$/,
+            /^([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})[\s]*([NnSs])[\W]*([0-9]{1,3}):([0-9]{1,2}):([0-9]{1,2})[\s]*([EeWw])$/,
+            /^(\d{1,2})[\s:](\d{1,2})\.(\d{1,3})\s*([NnSs])\s*(\d{1,3})[\s:](\d{1,2})\.(\d{1,3})\s*([EeWw])$/
+        ];
+        for (count = 0; count < pointregex.length; count++) {
+            matchref = instr.match(pointregex[count]);
+            if (matchref) {
+                switch (count) {
+                    case 0:
+                    case 1:
+                        //BGA or Welt2000 point
+                        $.ajax({
+                            url: "findtp.php",
+                            data: { postdata: matchref[0] },
+                            timeout: 3000,
+                            method: "POST",
+                            dataType: "json",
+                            async: false,
+                            success: function (data) {
+                                pointname = data.tpname;
+                                if (pointname !== "Not found") {
+                                    latitude = data.latitude;
+                                    longitude = data.longitude;
+                                    statusmessage = "OK";
+                                }
+                            }
+                        });
+                        break;
+                    case 2:
+                        //format in IGC file
+                        latitude = parseFloat(matchref[1]) + parseFloat(matchref[2]) / 60 + parseFloat(matchref[3]) / 60000;
+                        if (matchref[4].toUpperCase() === "S") {
+                            latitude = -latitude;
                         }
-});
-}
-    
+                        longitude = parseFloat(matchref[5]) + parseFloat(matchref[6]) / 60 + parseFloat(matchref[7]) / 60000;
+                        if (matchref[8].toUpperCase() === "W") {
+                            longitude = -longitude;
+                        }
+                        if (matchref[9].length > 0) {
+                            pointname = matchref[9];
+                        }
+                        statusmessage = "OK";
+
+                        break;
+                    case 3:
+                        //hh:mm:ss
+                        latitude = parseFloat(matchref[1]) + parseFloat(matchref[2]) / 60 + parseFloat(matchref[3]) / 3600;
+                        if (matchref[4].toUpperCase() === "S") {
+                            latitude = -latitude;
+                        }
+                        longitude = parseFloat(matchref[5]) + parseFloat(matchref[6]) / 60 + parseFloat(matchref[7]) / 3600;
+                        if (matchref[8].toUpperCase() === "W") {
+                            longitude = -longitude;
+                        }
+                        statusmessage = "OK";
+                        break;
+                    case 4:
+                        latitude = parseFloat(matchref[1]) + parseFloat(matchref[2]) / 60 + parseFloat(matchref[3]) / (60 * (Math.pow(10, matchref[3].length)));
+                        if (matchref[4].toUpperCase() === "S") {
+                            latitude = -latitude;
+                        }
+                        longitude = parseFloat(matchref[5]) + parseFloat(matchref[6]) / 60 + parseFloat(matchref[7]) / (60 * (Math.pow(10, matchref[7].length)));
+                        if (matchref[8].toUpperCase() === "W") {
+                            longitude = -longitude;
+                        }
+                        statusmessage = "OK";
+                        break;
+                }
+            }
+        }
+
+        return {
+            message: statusmessage,
+            coords: L.latLng(latitude, longitude),
+            name: pointname
+        };
+
+    }
+
+    function parseUserTask() {
+        var input;
+        var pointdata;
+        var success = true;
+        var taskdata = {
+            coords: [],
+            name: []
+        }
+        $("#requestdata :input[type=text]").each(function () {
+            input = $(this).val().replace(/ /g, '');
+            if (input.length > 0) {
+                pointdata = getPoint(input);
+                if (pointdata.message === "OK") {
+                    taskdata.coords.push(pointdata.coords);
+                    taskdata.name.push(pointdata.name);
+                }
+                else {
+                    success = false;
+                    alert("\"" + $(this).val() + "\"" + " not recognised-" + " ignoring entry");
+                }
+            }
+        });
+        if (success) {
+            task = maketask(taskdata);
+        }
+        else {
+            task = null;
+        }
+    }
+
+    function displaydate(timestamp) {
+        var daynames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+        var monthnames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+        return daynames[timestamp.getUTCDay()] + " " + timestamp.getUTCDate() + " " + monthnames[timestamp.getUTCMonth()] + " " + timestamp.getUTCFullYear();
+    }
+
+    //get timezone data from timezonedb.  Via php to avoid cross-domain data request from the browser
+    //Timezone dependent processes run  on file load are here as request is asynchronous
+    //If the request fails or times out, silently reverts to default (UTC)
+    function gettimezone(igcFile, mapControl) {
+        var flightdate = igcFile.recordTime[0];
+        $.ajax({
+            url: "gettimezone.php",
+            data: {
+                stamp: flightdate / 1000,
+                lat: igcFile.latLong[0][0],
+                lon: igcFile.latLong[0][1]
+            },
+            timeout: 3000,
+            method: "POST",
+            dataType: "json",
+            success: function (data) {
+                if (data.status === "OK") {
+                    timezone.zonename = data.zoneName;
+                    timezone.zoneabbr = data.abbreviation;
+                    timezone.offset = 1000 * parseFloat(data.gmtOffset);
+                    if (data.dst === "1") {
+                        timezone.zonename += ", daylight saving";
+                    }
+                }
+            },
+            complete: function () {
+                //Local date may not be the same as UTC date
+                var localdate = new Date(flightdate.getTime() + timezone.offset);
+                $('#datecell').text(displaydate(localdate));
+                barogramPlot = plotBarogram(igcFile);
+                updateTimeline(0, mapControl);
+            }
+        });
+    }
+
     function pad(n) {
         return (n < 10) ? ("0" + n.toString()) : n.toString();
     }
-    
+
     function plotBarogram() {
         var nPoints = igcFile.recordTime.length;
         var pressureBarogramData = [];
@@ -285,110 +285,110 @@ function gettimezone(igcFile,mapControl)  {
             label: 'Pressure altitude',
             data: pressureBarogramData
         }, {
-            label: 'GPS altitude',
-            data: gpsBarogramData
-        }],
-        {
-             axisLabels: {
-                show: true
-            },
-           xaxis: {
-                mode: 'time',
-                timeformat: '%H:%M',
-                axisLabel: 'Time (' + timezone.zonename +')'
-            },
-         yaxis: {
-                axisLabel: 'Altitude / ' + $('#altitudeUnits').val()
-            },
-            
-            crosshair: {
-                mode: 'xy'
-            },
-            
-            grid: {
-                clickable: true,
-                autoHighlight: false
+                label: 'GPS altitude',
+                data: gpsBarogramData
+            }],
+            {
+                axisLabels: {
+                    show: true
+                },
+                xaxis: {
+                    mode: 'time',
+                    timeformat: '%H:%M',
+                    axisLabel: 'Time (' + timezone.zonename + ')'
+                },
+                yaxis: {
+                    axisLabel: 'Altitude / ' + $('#altitudeUnits').val()
+                },
+
+                crosshair: {
+                    mode: 'xy'
+                },
+
+                grid: {
+                    clickable: true,
+                    autoHighlight: false
+                }
             }
-        }
-        );
+            );
         return baro;
     }
-    
-    function updateTimeline (timeIndex, mapControl) {
+
+    function updateTimeline(timeIndex, mapControl) {
         var currentPosition = igcFile.latLong[timeIndex];
         //var positionText=positionDisplay(currentPosition);
-        var positionText=pointDescription(L.latLng(currentPosition));
+        var positionText = pointDescription(L.latLng(currentPosition));
         var unitName = $('#altitudeUnits').val();
         //add in offset from UTC then convert back to UTC to get correct time in timezone!
-        var adjustedTime= new Date(igcFile.recordTime[timeIndex].getTime() + timezone.offset);
-       $('#timePositionDisplay').html(adjustedTime.getUTCHours() + ':' +pad(adjustedTime.getUTCMinutes()) + ':' + pad(adjustedTime.getSeconds()) +  " " + timezone.zoneabbr + '; '+ 
+        var adjustedTime = new Date(igcFile.recordTime[timeIndex].getTime() + timezone.offset);
+        $('#timePositionDisplay').html(adjustedTime.getUTCHours() + ':' + pad(adjustedTime.getUTCMinutes()) + ':' + pad(adjustedTime.getSeconds()) + " " + timezone.zoneabbr + '; ' +
             (igcFile.pressureAltitude[timeIndex] * altitudeConversionFactor).toFixed(0) + ' ' +
             unitName + ' (barometric) / ' +
             (igcFile.gpsAltitude[timeIndex] * altitudeConversionFactor).toFixed(0) + ' ' +
             unitName + ' (GPS); ' +
             positionText);
         mapControl.setTimeMarker(timeIndex);
-        
+
         barogramPlot.lockCrosshair({
-           x: adjustedTime.getTime(),
-           y: igcFile.pressureAltitude[timeIndex] * altitudeConversionFactor
+            x: adjustedTime.getTime(),
+            y: igcFile.pressureAltitude[timeIndex] * altitudeConversionFactor
         });
     }
-    
+
     function bindTaskButtons(mapControl) {
-        $('#taskbuttons button').on('click', function(event) {
-        var li=$(this).index();
-       mapControl.showTP(task.coords[li]);
-         });
+        $('#taskbuttons button').on('click', function (event) {
+            var li = $(this).index();
+            mapControl.showTP(task.coords[li]);
+        });
     }
-    
+
     function displayIgc(mapControl) {
-        
+
         clearTask(mapControl);
         //check for user entered task- must be entry in start and finish
-         if($('#start').val().trim() && $('#finish').val().trim())  {
-              parseUserTask();
-         }
-         //if user defined task is empty or malformed
-         if(task===null)  {
-            if(igcFile.taskpoints.length > 4) {
-           var i;
-            var pointdata;
-            var taskdata= {
-                   coords: [],
+        if ($('#start').val().trim() && $('#finish').val().trim()) {
+            parseUserTask();
+        }
+        //if user defined task is empty or malformed
+        if (task === null) {
+            if (igcFile.taskpoints.length > 4) {
+                var i;
+                var pointdata;
+                var taskdata = {
+                    coords: [],
                     name: []
-            };
-            //For now, ignore takeoff and landing
-             for(i=1;   i  < igcFile.taskpoints.length -1; i++) {
-                 pointdata= getPoint( igcFile.taskpoints[i]);
-                 if(pointdata.message==="OK") {
-                     taskdata.coords.push(pointdata.coords);
-                     taskdata.name.push(pointdata.name);
-                 }
-               }
-               if(taskdata.name.length > 1) {
-                    task= maketask(taskdata);
-               }
-           }
-         }
-         
-      if(task!==null) {
-           showTask();
-            mapControl.addTask(task.coords,task.labels);
+                };
+                //For now, ignore takeoff and landing
+                for (i = 1; i < igcFile.taskpoints.length - 1; i++) {
+                    pointdata = getPoint(igcFile.taskpoints[i]);
+                    if (pointdata.message === "OK") {
+                        taskdata.coords.push(pointdata.coords);
+                        taskdata.name.push(pointdata.name);
+                    }
+                }
+                if (taskdata.name.length > 1) {
+                    task = maketask(taskdata);
+                }
+            }
+        }
+
+        if (task !== null) {
+            showTask();
+            mapControl.addTask(task.coords, task.labels);
             //Need to bind event after buttons are created
-        bindTaskButtons(mapControl);
-      }
+            bindTaskButtons(mapControl);
+        }
         // Display the headers.
         var headerBlock = $('#headers');
         headerBlock.html('');
-       //Delay display of date till we get the timezone
+        //Delay display of date till we get the timezone
         var headerName;
         var headerIndex;
-      for (headerIndex = 0; headerIndex < igcFile.headers.length; headerIndex++) {
-           headerBlock.append(
+        for (headerIndex = 0; headerIndex < igcFile.headers.length; headerIndex++) {
+            headerBlock.append(
                 $('<tr></tr>').append($('<th></th>').text(igcFile.headers[headerIndex].name))
-                              .append($('<td></td>').text(igcFile.headers[headerIndex].value))
-            );
+                    .append($('<td></td>').text(igcFile.headers[headerIndex].value))
+                );
         }
         $('#flightInfo').show();
         // Reveal the map and graph. We have to do this before
@@ -396,17 +396,17 @@ function gettimezone(igcFile,mapControl)  {
         $('#igcFileDisplay').show();
         mapControl.addTrack(igcFile.latLong);
         //Barogram is now plotted on "complete" event of timezone query
-        gettimezone(igcFile,mapControl);
-       // Set airspace clip altitude to selected value and show airspace for the current window
-        mapControl.updateAirspace(Number( $("#airclip").val()));
+        gettimezone(igcFile, mapControl);
+        // Set airspace clip altitude to selected value and show airspace for the current window
+        mapControl.updateAirspace(Number($("#airclip").val()));
         //Enable automatic update of the airspace layer as map moves or zooms
         mapControl.activateEvents();
         $('#timeSlider').prop('max', igcFile.recordTime.length - 1);
     }
-        
+
     function pad(n) {
-    return (n < 10) ? ("0" + n) : n;
-}
+        return (n < 10) ? ("0" + n) : n;
+    }
 
     function storePreference(name, value) {
         if (window.localStorage) {
@@ -420,47 +420,47 @@ function gettimezone(igcFile,mapControl)  {
     }
 
     $(document).ready(function () {
-        var mapControl = createMapControl('map');  
+        var mapControl = createMapControl('map');
         var altitudeUnit = $('#altitudeUnits').val();
-            if (altitudeUnit === 'feet') {
-                altitudeConversionFactor = 3.2808399;
-            }
-            else {
-                altitudeConversionFactor = 1.0;
-            }
-            
+        if (altitudeUnit === 'feet') {
+            altitudeConversionFactor = 3.2808399;
+        }
+        else {
+            altitudeConversionFactor = 1.0;
+        }
+
         $('#fileControl').change(function () {
             if (this.files.length > 0) {
                 var reader = new FileReader();
-                reader.onload = function(e)  {
-                  try {
-                      $('#errorMessage').text('');
-                      mapControl.reset();
-                      $('#timeSlider').val(0);
-                      igcFile = parseIGC(this.result);
-                      
-                      displayIgc(mapControl);
-                  } catch (ex) {
-                      if (ex instanceof IGCException) {
-                          $('#errorMessage').text(ex.message);
-                      }
-                      else {
-                          throw ex;
-                      }
-                  }
+                reader.onload = function (e) {
+                    try {
+                        $('#errorMessage').text('');
+                        mapControl.reset();
+                        $('#timeSlider').val(0);
+                        igcFile = parseIGC(this.result);
+
+                        displayIgc(mapControl);
+                    } catch (ex) {
+                        if (ex instanceof IGCException) {
+                            $('#errorMessage').text(ex.message);
+                        }
+                        else {
+                            throw ex;
+                        }
+                    }
                 };
                 reader.readAsText(this.files[0]);
             }
         });
 
-        $('#help').click(function() {
+        $('#help').click(function () {
             window.open("igchelp.html", "_blank");
         });
-        
-         $('#about').click(function() {
+
+        $('#about').click(function () {
             window.open("igcabout.html", "_blank");
         });
-        
+
         $('#altitudeUnits').change(function (e, raisedProgrammatically) {
             var altitudeUnit = $(this).val();
             if (altitudeUnit === 'feet') {
@@ -482,77 +482,77 @@ function gettimezone(igcFile,mapControl)  {
         // We need to handle the 'change' event for IE, but
         // 'input' for Chrome and Firefox in order to update smoothly
         // as the range input is dragged.
-        $('#timeSlider').on('input', function() {
-          var t = parseInt($(this).val(), 10);
-          updateTimeline(t, mapControl);
+        $('#timeSlider').on('input', function () {
+            var t = parseInt($(this).val(), 10);
+            updateTimeline(t, mapControl);
         });
-        $('#timeSlider').on('change', function() {
-           var t = parseInt($(this).val(), 10);
-           updateTimeline(t, mapControl);
+        $('#timeSlider').on('change', function () {
+            var t = parseInt($(this).val(), 10);
+            updateTimeline(t, mapControl);
         });
-        
+
         $('#airclip').change(function () {
             var clipping = $(this).val();
             if (igcFile !== null) {
                 mapControl.updateAirspace(Number(clipping));
             }
             storePreference("airspaceClip", clipping);
-         });  
-  
-         $('#clearTask').click(function() {
-            $("#requestdata :input[type=text]").each(function() {
-             $(this).val("");
-    });
-           clearTask(mapControl);
-    });
-    
-    $('#zoomtrack').click(function() {
-        mapControl.zoomToTrack();
-    });
-         
-    $('button.toggle').click(
-            function(){
-                $(this).next().toggle();
-              if($(this).next().is(':visible')) {
-                  $(this).text('Hide');
-              }
-              else {
-                  $(this).text('Show');
-              }
+        });
+
+        $('#clearTask').click(function () {
+            $("#requestdata :input[type=text]").each(function () {
+                $(this).val("");
             });
-    
-        $('#enterTask').click(function() {
-       clearTask(mapControl);
-       parseUserTask();
-       showTask();
-       mapControl.addTask(task.coords,task.labels);
-       bindTaskButtons(mapControl);
-    });
-        
-         $('#barogram').on('plotclick', function (event, pos, item) {
-             if (item) {
-                 updateTimeline(item.dataIndex, mapControl);
-                 $('#timeSlider').val(item.dataIndex);
-             }
-         });
+            clearTask(mapControl);
+        });
 
-         var altitudeUnit = '', airspaceClip = '';
-         if (window.localStorage) {
-             try {
-                 altitudeUnit = localStorage.getItem("altitudeUnit");
-                 if (altitudeUnit) {
-                     $('#altitudeUnits').val(altitudeUnit).trigger('change', true);
-                 }
+        $('#zoomtrack').click(function () {
+            mapControl.zoomToTrack();
+        });
 
-                 airspaceClip = localStorage.getItem("airspaceClip");
-                 if (airspaceClip) {
-                     $('#airclip').val(airspaceClip);
-                 }
-             }
-             catch (e) {
-                 // If permission is denied, ignore the error.
-             }
-         }  
+        $('button.toggle').click(
+            function () {
+                $(this).next().toggle();
+                if ($(this).next().is(':visible')) {
+                    $(this).text('Hide');
+                }
+                else {
+                    $(this).text('Show');
+                }
+            });
+
+        $('#enterTask').click(function () {
+            clearTask(mapControl);
+            parseUserTask();
+            showTask();
+            mapControl.addTask(task.coords, task.labels);
+            bindTaskButtons(mapControl);
+        });
+
+        $('#barogram').on('plotclick', function (event, pos, item) {
+            if (item) {
+                updateTimeline(item.dataIndex, mapControl);
+                $('#timeSlider').val(item.dataIndex);
+            }
+        });
+
+        var altitudeUnit = '', airspaceClip = '';
+        if (window.localStorage) {
+            try {
+                altitudeUnit = localStorage.getItem("altitudeUnit");
+                if (altitudeUnit) {
+                    $('#altitudeUnits').val(altitudeUnit).trigger('change', true);
+                }
+
+                airspaceClip = localStorage.getItem("airspaceClip");
+                if (airspaceClip) {
+                    $('#airclip').val(airspaceClip);
+                }
+            }
+            catch (e) {
+                // If permission is denied, ignore the error.
+            }
+        }
     });
- 
-}(jQuery));
+
+} (jQuery));

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="initial-scale=1, width=device-width">
@@ -22,21 +23,22 @@
     <script src="mapcontrol.js"></script>
     <script src="igcviewer.js"></script>
 </head>
-<body>
-<button id='help'>Help</button>
-<button id='about'>About</button>
- <div id='titlediv'>
-    <h1>IGC Webview</h1>
 
-    <p>
-        A free browser-based tool for viewing IGC format  tracks and barograph traces from gliding loggers.
-    </p>
-    <p> &copy; 2015 Alistair Malcolm Green and Richard Brisbourne </p>
-      <p>
-        <label for="fileControl"><b>Select a file to view:</b></label>
-        <input id="fileControl" type="file"  accept=".igc" class="inbutton"/>
-    </p>
-</div>
+<body>
+    <button id='help'>Help</button>
+    <button id='about'>About</button>
+    <div id='titlediv'>
+        <h1>IGC Webview</h1>
+
+        <p>
+            A free browser-based tool for viewing IGC format tracks and barograph traces from gliding loggers.
+        </p>
+        <p> &copy; 2015 Alistair Malcolm Green and Richard Brisbourne </p>
+        <p>
+            <label for="fileControl"><b>Select a file to view:</b></label>
+            <input id="fileControl" type="file" accept=".igc" class="inbutton" />
+        </p>
+    </div>
     <noscript>
         <p>
             <strong>Please enable JavaScript to use this application.</strong>
@@ -44,24 +46,26 @@
     </noscript>
     <div id="errorMessage">
     </div>
-  
+
 
     <div class="halfwidth">
-      <h2> Preferences </h2>
-      <button class='toggle'>Hide</button>
-      <div class='hideable'>
-    <p>
-    <b>Warning:</b> Unless the "no airspace" option is selected below, outlines of controlled airspace  will be displayed on the map provided we have data for the area.</p>
-    <p>This information may not be accurate,  current or complete and is not valid for navigation or flight planning.   Always consult the official publications for current and correct information. 
-    </p>
-    <p>
-        <label for="altitudeUnits">Altitude units:</label>
-        <select id="altitudeUnits" class="inbutton">
-            <option value="feet">Feet</option>
-            <option value="metres">Metres</option>
-        </select>
-        &nbsp;&nbsp; 
-        <span class="nowrap">
+        <h2> Preferences </h2>
+        <button class='toggle'>Hide</button>
+        <div class='hideable'>
+            <p>
+                <b>Warning:</b> Unless the "no airspace" option is selected below, outlines of controlled airspace will be
+                displayed on the map provided we have data for the area.</p>
+            <p>This information may not be accurate, current or complete and is not valid for navigation or flight planning.
+                Always consult the official publications for current and correct information.
+            </p>
+            <p>
+                <label for="altitudeUnits">Altitude units:</label>
+                <select id="altitudeUnits" class="inbutton">
+                    <option value="feet">Feet</option>
+                    <option value="metres">Metres</option>
+                </select>
+                &nbsp;&nbsp;
+                <span class="nowrap">
         <label for="airclip">Clip airspace above:</label>
         <select id="airclip" class="inbutton">
            <option value="0">No Airspace</option>
@@ -73,66 +77,76 @@
             <option value="19501">19500 feet</option>
         </select>
         </span>
-    </p>
+            </p>
+        </div>
     </div>
- </div>
     <div class="halfwidth" id="declaration">
-    <h2>Task- user entry </h2>
-      <button class='toggle'>Hide</button>
-      <div>
-    <p>Fill in this section if the task declaration in the IGC file is absent or incorrect.  It will override any declaration in the file.  To use the declaration in the IGC file leave it blank.</p>
-    <p>You may enter <a href="http://www.spsys.demon.co.uk/turningpoints.htm" target="_blank">BGA trigraphs</a>, six character codes for waypoints on the <a href="http://www.segelflug.de/vereine/welt2000/" target="_blank"> Welt2000 database</a>  or Lat/Long in either  'dd:mm.mmm&nbsp;N&nbsp;ddd:mm.mmm&nbsp;W' or 'dd:mm:ss&nbsp;N&nbsp;ddd:mm:ss&nbsp;W' format.  Start and finish must be filled in, blank turning points will be ignored.</p>
-    <p id="requestdata">
-    <span class="nowrap">Start: <input type="text" id="start"/>&nbsp;</span>
-    <span class="nowrap">TP1:&nbsp;<input type="text"/>&nbsp;</span>
-    <span class="nowrap">TP2:&nbsp;<input type="text"/>&nbsp;</span>
-    <span class="nowrap">TP3: <input type="text"/>&nbsp;</span>
-    <span class="nowrap"> TP4:  <input type="text"/>&nbsp;</span>
-    <span class="nowrap">Finish: <input type="text" id="finish"/></span>
-    <br><button id="enterTask" class="inbutton">Enter</button> <button id="clearTask" class="inbutton">Clear</button></p>
-    
-</div>
+        <h2>Task- user entry </h2>
+        <button class='toggle'>Hide</button>
+        <div>
+            <p>Fill in this section if the task declaration in the IGC file is absent or incorrect. It will override any declaration
+                in the file. To use the declaration in the IGC file leave it blank.</p>
+            <p>You may enter <a href="http://www.spsys.demon.co.uk/turningpoints.htm" target="_blank">BGA trigraphs</a>, six
+                character codes for waypoints on the <a href="http://www.segelflug.de/vereine/welt2000/" target="_blank"> Welt2000 database</a>                or Lat/Long in either 'dd:mm.mmm&nbsp;N&nbsp;ddd:mm.mmm&nbsp;W' or 'dd:mm:ss&nbsp;N&nbsp;ddd:mm:ss&nbsp;W'
+                format. Start and finish must be filled in, blank turning points will be ignored.</p>
+            <p id="requestdata">
+                <span class="nowrap">Start: <input type="text" id="start"/>&nbsp;</span>
+                <span class="nowrap">TP1:&nbsp;<input type="text"/>&nbsp;</span>
+                <span class="nowrap">TP2:&nbsp;<input type="text"/>&nbsp;</span>
+                <span class="nowrap">TP3: <input type="text"/>&nbsp;</span>
+                <span class="nowrap"> TP4:  <input type="text"/>&nbsp;</span>
+                <span class="nowrap">Finish: <input type="text" id="finish"/></span>
+                <br>
+                <button id="enterTask" class="inbutton">Enter</button>
+                <button id="clearTask" class="inbutton">Clear</button>
+            </p>
 
-<div id="task">
+        </div>
+
+        <div id="task">
             <h2> Task </h2>
             <button class='toggle'>Hide</button>
-    <div>
-           <table>
-           <tbody id="taskinfo">
-           </tbody>
-           </table>
-            <p id="tasklength"></p>
-        </div> 
-</div>  
-</div>
-
-<div id="flightInfo">
-    <h2> Flight Information </h2>
-     <button class='toggle'>Hide</button>
-     <div>
-        <table id="headerInfo">
-                 <tbody>
-             <tr><th>Date:</th><td id='datecell'></td>
-             </tbody>
-            <tbody id="headers">
-            </tbody>
-        </table>
+            <div>
+                <table>
+                    <tbody id="taskinfo">
+                    </tbody>
+                </table>
+                <p id="tasklength"></p>
+            </div>
+        </div>
     </div>
+
+    <div id="flightInfo">
+        <h2> Flight Information </h2>
+        <button class='toggle'>Hide</button>
+        <div>
+            <table id="headerInfo">
+                <tbody>
+                    <tr>
+                        <th>Date:</th>
+                        <td id='datecell'></td>
+                </tbody>
+                <tbody id="headers">
+                </tbody>
+            </table>
+        </div>
     </div>
     <br>
-    <div id="igcFileDisplay" >    
+    <div id="igcFileDisplay">
 
         <div id="mapWrapper" class="halfwidth">
             <div id="map"></div>
             <div id="slider">
-            <label for="timeSlider">Time:</label>
-            <input type="range" id="timeSlider" step="1" value="0" min="0" max="100"/>
-            <p id="timePositionDisplay"></p>
-        </div>
-        <p>Zoom:  <button id="zoomtrack">Track</button>&nbsp;&nbsp;<span id="taskbuttons"></span></p>
+                <label for="timeSlider">Time:</label>
+                <input type="range" id="timeSlider" step="1" value="0" min="0" max="100" />
+                <p id="timePositionDisplay"></p>
+            </div>
+            <p>Zoom:
+                <button id="zoomtrack">Track</button>&nbsp;&nbsp;<span id="taskbuttons"></span></p>
         </div>
         <div id="barogram" class="halfwidth"></div>
     </div>
 
 </body>
+
 </html>

--- a/mapcontrol.js
+++ b/mapcontrol.js
@@ -35,8 +35,8 @@ function createMapControl(elementName) {
         //assume earth is a sphere circumference 40030 Km 
         var latdelta = linerad * longdiff / hypotenuse / 111.1949269;
         var longdelta = linerad * latdiff / hypotenuse / 111.1949269 / Math.cos(startrads);
-        var linestart =  L.latLng(pt1['lat'] - latdelta, pt1['lng'] - longdelta);
-        var lineend =  L.latLng(pt1['lat'] + latdelta, longdelta + pt1['lng']);
+        var linestart = L.latLng(pt1['lat'] - latdelta, pt1['lng'] - longdelta);
+        var lineend = L.latLng(pt1['lat'] + latdelta, longdelta + pt1['lng']);
         var polylinePoints = [linestart, lineend];
         var polylineOptions = {
             color: 'green',
@@ -67,64 +67,64 @@ function createMapControl(elementName) {
         return L.circle(centrept, sectorRadius, sectorOptions);
     }
 
-//Airspace control functions are now private to facilitate calling from the map move event
+    //Airspace control functions are now private to facilitate calling from the map move event
 
- function zapAirspace()  {
-                if (mapLayers.airspace) {
-                map.removeLayer(mapLayers.airspace);
-            }
- }
+    function zapAirspace() {
+        if (mapLayers.airspace) {
+            map.removeLayer(mapLayers.airspace);
+        }
+    }
 
     function showAirspace() {
-       var mapbounds= map.getBounds();
+        var mapbounds = map.getBounds();
 
-       //Don't show airspace if the map is zoomed out so north/south latitude distance is over 10 degrees
-       //roughly 1000 Km. Too much data in the layer slows everything down.
-       //Values here are a tradeoff between window size,  smooth factor and responsiveness
-       if ((airClip >0) && ((mapbounds.getNorth()- mapbounds.getSouth()) < 10)) {
-       $.post("getairspace.php",
-           {
-               maxNorth: mapbounds.getNorth(),
-               minNorth: mapbounds.getSouth(),
-               maxEast: mapbounds.getEast() ,
-                minEast: mapbounds.getWest()
-        } ,
-              function(data,status) {
-              if(status==="success")  {
-                     $('#airspace_src').html(data.country);
-                     $('#airspace_info').show();
-                     var i;
-                    var polyPoints;
-                     var suacircle;
-                     var airStyle = {
-                    "color": "black",
-                    "weight": 1,
-                    "opacity": 0.20,
-                    "fillColor": "red",
-                    "smoothFactor": 1
-                    };
-                var suafeatures=[];
-                zapAirspace();
+        //Don't show airspace if the map is zoomed out so north/south latitude distance is over 10 degrees
+        //roughly 1000 Km. Too much data in the layer slows everything down.
+        //Values here are a tradeoff between window size,  smooth factor and responsiveness
+        if ((airClip > 0) && ((mapbounds.getNorth() - mapbounds.getSouth()) < 10)) {
+            $.post("getairspace.php",
+                {
+                    maxNorth: mapbounds.getNorth(),
+                    minNorth: mapbounds.getSouth(),
+                    maxEast: mapbounds.getEast(),
+                    minEast: mapbounds.getWest()
+                },
+                function (data, status) {
+                    if (status === "success") {
+                        $('#airspace_src').html(data.country);
+                        $('#airspace_info').show();
+                        var i;
+                        var polyPoints;
+                        var suacircle;
+                        var airStyle = {
+                            "color": "black",
+                            "weight": 1,
+                            "opacity": 0.20,
+                            "fillColor": "red",
+                            "smoothFactor": 1
+                        };
+                        var suafeatures = [];
+                        zapAirspace();
 
-            for(i=0 ; i < data.polygons.length;i++) {
-                if(data.polygons[i].base < airClip)  {
-                  polyPoints=data.polygons[i].coords;
-                    suafeatures.push(L.polygon(polyPoints,airStyle));
-                }
-            }
-            for(i=0; i < data.circles.length; i++) {
-                if (data.circles[i].base <  airClip)  {
-                    suafeatures.push(L.circle(data.circles[i].centre, 1000*data.circles[i].radius, airStyle));
+                        for (i = 0; i < data.polygons.length; i++) {
+                            if (data.polygons[i].base < airClip) {
+                                polyPoints = data.polygons[i].coords;
+                                suafeatures.push(L.polygon(polyPoints, airStyle));
+                            }
+                        }
+                        for (i = 0; i < data.circles.length; i++) {
+                            if (data.circles[i].base < airClip) {
+                                suafeatures.push(L.circle(data.circles[i].centre, 1000 * data.circles[i].radius, airStyle));
+                            }
+                        }
+                        mapLayers.airspace = L.layerGroup(suafeatures).addTo(map); 
+                        // layersControl.addOverlay(mapLayers.airspace, 'Airspace');
                     }
-                }
-                    mapLayers.airspace = L.layerGroup(suafeatures).addTo(map); 
-                  // layersControl.addOverlay(mapLayers.airspace, 'Airspace');
-                       }
-    },"json");
+                }, "json");
         }
-    else  {
-        zapAirspace();
-    }
+        else {
+            zapAirspace();
+        }
     }
 
     // End of private methods
@@ -132,21 +132,21 @@ function createMapControl(elementName) {
     var map = L.map(elementName);
 
     //Airspace clip altitude and initial bounds now a property of this object
-   var airClip= 0;
-   
-   var initBounds;
+    var airClip = 0;
+
+    var initBounds;
 
     var mapQuestAttribution = ' | Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">';
     var mapLayers = {
         openStreetMap: L.tileLayer('http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.jpg', {
             attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>' +
-                         mapQuestAttribution,
+            mapQuestAttribution,
             maxZoom: 18
         }),
 
         photo: L.tileLayer('http://otile1.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.jpg', {
             attribution: 'Portions Courtesy NASA/JPL-Caltech and U.S. Depart. of Agriculture, Farm Service Agency' +
-                         mapQuestAttribution,
+            mapQuestAttribution,
             maxZoom: 11
         })
     };
@@ -166,7 +166,7 @@ function createMapControl(elementName) {
         iconColor: 'white',
         markerColor: 'red'
     });
-    
+
     return {
         reset: function () {
             // Clear any existing track data so that a new file can be loaded.
@@ -183,29 +183,29 @@ function createMapControl(elementName) {
 
         addTrack: function (latLong) {
             trackLatLong = latLong;
-            var trackLine = L.polyline(latLong, { color: 'blue' ,weight: 4});
+            var trackLine = L.polyline(latLong, { color: 'blue', weight: 4 });
             timePositionMarker = L.marker(latLong[0], { icon: planeIcon });
             mapLayers.track = L.layerGroup([
                 trackLine,
                 timePositionMarker
             ]).addTo(map);
             layersControl.addOverlay(mapLayers.track, 'Flight path');
-            initBounds=(trackLine.getBounds());
+            initBounds = (trackLine.getBounds());
             map.fitBounds(initBounds);
         },
-        
-        zoomToTrack: function() {
+
+        zoomToTrack: function () {
             map.fitBounds(initBounds);
         },
-        
-       zapTask: function()  {
+
+        zapTask: function () {
             if (mapLayers.task) {
                 map.removeLayer(mapLayers.task);
                 layersControl.removeLayer(mapLayers.task);
             }
         },
-        
-       addTask: function (coordinates, names) {
+
+        addTask: function (coordinates, names) {
             var taskLayers = [L.polyline(coordinates, { color: 'dimgray' })];
             var lineDrawOptions = {
                 fillColor: 'green',
@@ -215,7 +215,7 @@ function createMapControl(elementName) {
             };
             var sectorDrawOptions = {
                 fillColor: 'green',
-                fillOpacity :0.1,
+                fillOpacity: 0.1,
                 color: 'black',
                 weight: 1,
                 opacity: 0.8
@@ -229,45 +229,45 @@ function createMapControl(elementName) {
             var tpSectorAngle = 90;
             var j;
             for (j = 0; j < coordinates.length; j++) {
-               taskLayers.push(L.marker(coordinates[j]).bindPopup(names[j]));
+                taskLayers.push(L.marker(coordinates[j]).bindPopup(names[j]));
                 switch (j) {
                     case 0:
-                     var startline = getLine(coordinates[0], coordinates[1], startLineRadius, lineDrawOptions);
+                        var startline = getLine(coordinates[0], coordinates[1], startLineRadius, lineDrawOptions);
                         taskLayers.push(startline);
                         break;
                     case (coordinates.length - 1):
-                      var finishline = getLine(coordinates[j], coordinates[j - 1], finishLineRadius, lineDrawOptions);
-                       taskLayers.push(finishline);
+                        var finishline = getLine(coordinates[j], coordinates[j - 1], finishLineRadius, lineDrawOptions);
+                        taskLayers.push(finishline);
                         break;
-                       default:
-                       taskLayers.push(L.circle(coordinates[j], tpCircleRadius, sectorDrawOptions));
-                        var tpsector = getTpSector(coordinates[j], coordinates[j - 1], coordinates[j + 1], tpSectorRadius, tpSectorAngle,sectorDrawOptions);
-                       taskLayers.push(tpsector);
-                  }
-              }
+                    default:
+                        taskLayers.push(L.circle(coordinates[j], tpCircleRadius, sectorDrawOptions));
+                        var tpsector = getTpSector(coordinates[j], coordinates[j - 1], coordinates[j + 1], tpSectorRadius, tpSectorAngle, sectorDrawOptions);
+                        taskLayers.push(tpsector);
+                }
+            }
             mapLayers.task = L.layerGroup(taskLayers).addTo(map);
             layersControl.addOverlay(mapLayers.task, 'Task');
         },
-        
-        updateAirspace:  function(clip) {
-            airClip=clip;
-           showAirspace();
+
+        updateAirspace: function (clip) {
+            airClip = clip;
+            showAirspace();
         },
 
         //called to turn on airspace updating
-        activateEvents: function() {
-         map.on('moveend', showAirspace);
+        activateEvents: function () {
+            map.on('moveend', showAirspace);
         },
-        
-        showTP: function(tpoint) {
-            map.setView(tpoint,13);
+
+        showTP: function (tpoint) {
+            map.setView(tpoint, 13);
         },
 
         setTimeMarker: function (timeIndex) {
             var markerLatLng = trackLatLong[timeIndex];
             if (markerLatLng) {
                 timePositionMarker.setLatLng(markerLatLng);
-                
+
                 if (!map.getBounds().contains(markerLatLng)) {
                     map.panTo(markerLatLng);
                 }

--- a/mapcontrol.js
+++ b/mapcontrol.js
@@ -1,3 +1,6 @@
+/* global jQuery */
+/* global L */
+/* global $ */
 // Wrapper for the leaflet.js map control with methods
 // to manage the map layers.
 function createMapControl(elementName) {
@@ -38,11 +41,6 @@ function createMapControl(elementName) {
         var linestart = L.latLng(pt1['lat'] - latdelta, pt1['lng'] - longdelta);
         var lineend = L.latLng(pt1['lat'] + latdelta, longdelta + pt1['lng']);
         var polylinePoints = [linestart, lineend];
-        var polylineOptions = {
-            color: 'green',
-            weight: 3,
-            opacity: 0.8
-        };
 
         return L.polyline(polylinePoints, drawOptions);
     }
@@ -95,7 +93,6 @@ function createMapControl(elementName) {
                         $('#airspace_info').show();
                         var i;
                         var polyPoints;
-                        var suacircle;
                         var airStyle = {
                             "color": "black",
                             "weight": 1,

--- a/parseigc.js
+++ b/parseigc.js
@@ -194,12 +194,10 @@ function parseIGC(igcFile) {
     });
 
     var flightDate = extractDate(igcFile);
-    var taskpoints = [];
     var lineIndex;
     var positionData;
     var recordType;
     var currentLine;
-    var turnpoint; // for task declaration lines
     var headerData;
 
     for (lineIndex = 0; lineIndex < igcLines.length; lineIndex++) {

--- a/parseigc.js
+++ b/parseigc.js
@@ -42,12 +42,12 @@ function parseIGC(igcFile) {
             manufacturer: 'Unknown',
             serial: aRecord.substring(4, 7)
         };
-        
+
         var manufacturerCode = aRecord.substring(1, 4);
         if (manufacturers[manufacturerCode]) {
             manufacturerInfo.manufacturer = manufacturers[manufacturerCode];
         }
-        
+
         return manufacturerInfo;
     }
 
@@ -124,8 +124,8 @@ function parseIGC(igcFile) {
 
         return [latitude, longitude];
     }
-    
-    function parsePosition(positionRecord,  model, flightDate) {
+
+    function parsePosition(positionRecord, model, flightDate) {
         // Regex to match position records:
         // Hours, minutes, seconds, latitude, N or S, longitude, E or W,
         // Fix validity ('A' = 3D fix, 'V' = 2D or no fix),
@@ -181,20 +181,20 @@ function parseIGC(igcFile) {
     if (!(/^A[\w]{6}/).test(igcLines[0])) {
         throw new IGCException(invalidFileMessage);
     }
-    
+
     var manufacturerInfo = parseManufacturer(igcLines[0]);
     model.headers.push({
         name: 'Logger manufacturer',
-        value: manufacturerInfo.manufacturer 
+        value: manufacturerInfo.manufacturer
     });
-    
+
     model.headers.push({
         name: 'Logger serial number',
         value: manufacturerInfo.serial
     });
 
     var flightDate = extractDate(igcFile);
-    var taskpoints= [];
+    var taskpoints = [];
     var lineIndex;
     var positionData;
     var recordType;
@@ -218,10 +218,10 @@ function parseIGC(igcFile) {
 
             case 'C': // Task declaration
                 var taskRegex = /^C[\d]{7}[NS][\d]{8}[EW].*/;
-               if( taskRegex.test(currentLine)) {
-                   //drop the "C" and push raw data to model.  Will parse later if needed using same functions as for user entered tasks
-                   model.taskpoints.push(currentLine.substring(1).trim());
-                    }
+                if (taskRegex.test(currentLine)) {
+                    //drop the "C" and push raw data to model.  Will parse later if needed using same functions as for user entered tasks
+                    model.taskpoints.push(currentLine.substring(1).trim());
+                }
                 break;
 
             case 'H': // Header information


### PR DESCRIPTION
- Reformats the code, making it easier to read by lining everything up neatly.
- Removes duplicate definition of the `pad()` function.
- Removes unused variables.

The easiest way to review these changes is by looking at each commit individually. Because of the reformatting, the overall diff shows lots of changes, most of which are white space only.

These changes need to be beta tested to make absolutely sure that I did not break anything.
