### PR TITLE
Fix #10 - Map not shown if there is no task.

### DIFF
--- a/igcviewer.js
+++ b/igcviewer.js
@@ -847,6 +847,7 @@ var ns = (function ($) {
         showTask();
       }
     }
+    $('#map').show();
     mapControl.setBounds(igcFile.bounds);
     if (enlStatus.detect === 'On') {
       engineRuns = getEngineState(igcFile, enlStatus);


### PR DESCRIPTION
Force map to be visible when a file is loaded, even if it did not contain a task.
